### PR TITLE
Add danielballan to the maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @conda-forge/event-model @hhslepicka @klauer @mrakitin @tacaswell
+* @conda-forge/event-model @danielballan @hhslepicka @klauer @mrakitin @tacaswell

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Feedstock Maintainers
 =====================
 
 * [@conda-forge/event-model](https://github.com/conda-forge/event-model/)
+* [@danielballan](https://github.com/danielballan/)
 * [@hhslepicka](https://github.com/hhslepicka/)
 * [@klauer](https://github.com/klauer/)
 * [@mrakitin](https://github.com/mrakitin/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,8 +46,8 @@ about:
 extra:
   recipe-maintainers:
     - conda-forge/event-model
-    - hhslepicka
     - danielballan
-    - mrakitin
+    - hhslepicka
     - klauer
+    - mrakitin
     - tacaswell


### PR DESCRIPTION
No need for a new build number, it's just to rerender the feedstock to get @danielballan to the list of maintainers. Also, sort the maintainers list.

The final rerender was missing from #16.